### PR TITLE
Expose title property to views in order to fix blank title in HTML

### DIFF
--- a/config/env/production.js
+++ b/config/env/production.js
@@ -1,5 +1,8 @@
 'use strict';
 
 module.exports = {
-	db: process.env.MONGODB_URI || 'mongodb://localhost:27017/fb-prod'
+	db: process.env.MONGODB_URI || 'mongodb://localhost:27017/fb-prod',
+	app: {
+		title: 'Food Bank'
+	}
 };

--- a/config/express.js
+++ b/config/express.js
@@ -35,9 +35,10 @@ module.exports = function(db) {
 	app.locals.jsFiles = config.getGlobbedFiles(config.assets.lib.js, 'public/');
 	app.locals.cssFiles = config.getGlobbedFiles(config.assets.lib.css, 'public/');
 
-	// Passing the request url to environment locals
+	// Passing the request url and title to environment locals
 	app.use(function(req, res, next) {
 		res.locals.url = req.protocol + '://' + req.headers.host + req.url;
+		res.locals.title = config.app.title;
 		next();
 	});
 


### PR DESCRIPTION
One of the views attempts to use {{title}} which is not set.  This fixes it by setting res.locals.title from the config.app.title property so that views have access to the application title.  Also added a title property to the production env properties.
Closes #33