### PR TITLE
Fix client admin authorization code

### DIFF
--- a/public/modules/customer/config/admin-customer.client.routes.js
+++ b/public/modules/customer/config/admin-customer.client.routes.js
@@ -1,8 +1,8 @@
 'use strict';
 
 // Setting up route
-angular.module('customer').config(['$stateProvider',
-	function($stateProvider){
+angular.module('customer').config(['$stateProvider', 'AuthenticationProvider',
+	function($stateProvider, AuthenticationProvider){
 		// Customer state routing for admin
 		$stateProvider.
 		state('root.listCustomers', {
@@ -12,6 +12,9 @@ angular.module('customer').config(['$stateProvider',
 					templateUrl: 'modules/customer/views/admin/list-customers.client.view.html',
 					controller: 'CustomerAdminController as customerCtrl'
 				}
+			},
+			resolve: {
+				CurrentUser: AuthenticationProvider.requireAdminUser
 			}
 		}).
 		state('root.viewCustomerAdmin', {
@@ -21,6 +24,9 @@ angular.module('customer').config(['$stateProvider',
 					templateUrl: 'modules/customer/views/view-customer.client.view.html',
 					controller: 'CustomerAdminController as customerCtrl'
 				}
+			},
+			resolve: {
+				CurrentUser: AuthenticationProvider.requireAdminUser
 			}
 		}).
 		state('root.editCustomerAdmin', {
@@ -36,6 +42,9 @@ angular.module('customer').config(['$stateProvider',
 				'household@root.editCustomerAdmin': {
 					templateUrl: 'modules/customer/views/partials/household.partial.html'
 				}
+			},
+			resolve: {
+				CurrentUser: AuthenticationProvider.requireAdminUser
 			}
 		});
 	}

--- a/public/modules/customer/controllers/admin-customer.client.controller.js
+++ b/public/modules/customer/controllers/admin-customer.client.controller.js
@@ -3,17 +3,10 @@
 
 	/* @ngInject */
 	function CustomerAdminController($window, $stateParams, $state, Authentication, CustomerAdmin, Food, Form, SectionsAndFields) {
-		var self = this,
-				user = Authentication.user;
-
+		var self = this;
+		
 		// This provides Authentication context
 		self.authentication = Authentication;
-
-		// Verify is user has admin role, redirect to home otherwise
-		if (user && user.roles.indexOf('admin') < 0) {
-			$state.go('root');
-			return;
-		}
 
 		// If on edit view, not list view, initialize
 		if ($state.current.name === 'root.editCustomerAdmin') {

--- a/public/modules/customer/customer.client.module.js
+++ b/public/modules/customer/customer.client.module.js
@@ -1,4 +1,4 @@
 'use strict';
 
 // Use application configuration module to register a new module
-ApplicationConfiguration.registerModule('customer');
+ApplicationConfiguration.registerModule('customer', ['users']);

--- a/public/modules/donor/config/donor.client.routes.js
+++ b/public/modules/donor/config/donor.client.routes.js
@@ -1,8 +1,8 @@
 'use strict';
 
 // Setting up route
-angular.module('donor').config(['$stateProvider',
-	function($stateProvider) {
+angular.module('donor').config(['$stateProvider', 'AuthenticationProvider',
+	function($stateProvider, AuthenticationProvider) {
 		// Donor state routing for user
 		$stateProvider.
 		state('root.createDonorUser', {
@@ -56,6 +56,9 @@ angular.module('donor').config(['$stateProvider',
 					templateUrl: 'modules/donor/views/admin/list-donors.client.view.html',
 					controller: 'DonorAdminController as donorCtrl'
 				}
+			},
+			resolve: {
+				CurrentUser: AuthenticationProvider.requireAdminUser
 			}
 		}).
 		state('root.viewDonorAdmin', {
@@ -65,6 +68,9 @@ angular.module('donor').config(['$stateProvider',
 					templateUrl: 'modules/donor/views/view-donor.client.view.html',
 					controller: 'DonorAdminController as donorCtrl'
 				}
+			},
+			resolve: {
+				CurrentUser: AuthenticationProvider.requireAdminUser
 			}
 		}).
 		state('root.editDonorAdmin', {
@@ -77,6 +83,9 @@ angular.module('donor').config(['$stateProvider',
 				'general-info@root.editDonorAdmin': {
 					templateUrl: 'modules/donor/views/partials/general-info.partial.html'
 				}
+			},
+			resolve: {
+				CurrentUser: AuthenticationProvider.requireAdminUser
 			}
 		});
 	}

--- a/public/modules/donor/controllers/admin-donor.client.controller.js
+++ b/public/modules/donor/controllers/admin-donor.client.controller.js
@@ -18,10 +18,7 @@
 		self.newDonation = newDonation;
 		self.viewDonation = viewDonation;
 		self.remove = remove;
-
-		// Verify is user has admin role, redirect to home otherwise
-		if (Authentication.user.roles.indexOf('admin') < 0) $state.go('root');
-
+		
 		// Add plugins into datatable
 		self.dtOptions = {
 			dom: 'Tlfrtip',

--- a/public/modules/donor/donor.client.module.js
+++ b/public/modules/donor/donor.client.module.js
@@ -1,4 +1,4 @@
 'use strict';
 
 // Use application configuration module to register a new module
-ApplicationConfiguration.registerModule('donor');
+ApplicationConfiguration.registerModule('donor', ['users']);

--- a/public/modules/driver/config/driver.client.routes.js
+++ b/public/modules/driver/config/driver.client.routes.js
@@ -1,8 +1,8 @@
 'use strict';
 
 // Setting up routes
-angular.module('driver').config(['$stateProvider',
-	function($stateProvider) {
+angular.module('driver').config(['$stateProvider', 'AuthenticationProvider',
+	function($stateProvider, AuthenticationProvider) {
 		$stateProvider.
 		state('root.driver', {
 			abstract: true
@@ -25,6 +25,9 @@ angular.module('driver').config(['$stateProvider',
 					templateUrl: 'modules/driver/views/admin-driver.client.view.html',
 					controller: 'DriverAdminController as driverCtrl'
 				}
+			},
+			resolve: {
+				CurrentUser: AuthenticationProvider.requireAdminUser
 			}
 		}).
 		state('root.driver.routes', {
@@ -34,6 +37,9 @@ angular.module('driver').config(['$stateProvider',
 					templateUrl: 'modules/driver/views/routes-driver.client.view.html',
 					controller: 'DriverRouteController as driverCtrl'
 				}
+			},
+			resolve: {
+				CurrentUser: AuthenticationProvider.requireAdminUser
 			}
 		});
 	}

--- a/public/modules/driver/driver.client.module.js
+++ b/public/modules/driver/driver.client.module.js
@@ -1,4 +1,4 @@
 'use strict';
 
 // Use application configuration module to register a new module
-ApplicationConfiguration.registerModule('driver');
+ApplicationConfiguration.registerModule('driver', ['users']);

--- a/public/modules/food/config/food.client.routes.js
+++ b/public/modules/food/config/food.client.routes.js
@@ -1,8 +1,8 @@
 'use strict';
 
 // Setting up routes
-angular.module('food').config(['$stateProvider',
-	function($stateProvider) {
+angular.module('food').config(['$stateProvider', 'AuthenticationProvider',
+	function($stateProvider, AuthenticationProvider) {
 		// Food state routing
 		$stateProvider.
 		state('root.foods', {
@@ -12,6 +12,9 @@ angular.module('food').config(['$stateProvider',
 					templateUrl: 'modules/food/views/foods.client.view.html',
 					controller: 'FoodController as foodCtrl'
 				}
+			},
+			resolve: {
+				CurrentUser: AuthenticationProvider.requireAdminUser
 			}
 		});
 	}

--- a/public/modules/food/food.client.module.js
+++ b/public/modules/food/food.client.module.js
@@ -1,4 +1,4 @@
 'use strict';
 
 // Use application configuration module to register a new module
-ApplicationConfiguration.registerModule('food');
+ApplicationConfiguration.registerModule('food', ['users']);

--- a/public/modules/media/config/media.client.routes.js
+++ b/public/modules/media/config/media.client.routes.js
@@ -1,8 +1,8 @@
 'use strict';
 
 // Setting up routes
-angular.module('media').config(['$stateProvider', '$urlRouterProvider',
-	function($stateProvider, $urlRouterProvider) {
+angular.module('media').config(['$stateProvider', '$urlRouterProvider', 'AuthenticationProvider',
+	function($stateProvider, $urlRouterProvider, AuthenticationProvider) {
 		// Routing for general settings page
 		$stateProvider.
 		state('root.changeMedia', {
@@ -12,6 +12,9 @@ angular.module('media').config(['$stateProvider', '$urlRouterProvider',
 					templateUrl: 'modules/media/views/change-media.client.view.html',
 					controller: 'ChangeMediaController as mediaCtrl'
 				}
+			},
+			resolve: {
+				CurrentUser: AuthenticationProvider.requireAdminUser
 			}
 		});
 	}

--- a/public/modules/media/controllers/media.client.controller.js
+++ b/public/modules/media/controllers/media.client.controller.js
@@ -18,8 +18,5 @@
 
 		// This provides Authentication context
 		self.authentication = Authentication;
-
-		// If user is not signed in redirect to signin
-		if(!user) $state.go('root.signin');
 	}
 })();

--- a/public/modules/media/media.client.module.js
+++ b/public/modules/media/media.client.module.js
@@ -1,4 +1,4 @@
 'use strict';
 
 // Use application configuration module to register a new module
-ApplicationConfiguration.registerModule('media');
+ApplicationConfiguration.registerModule('media', ['users']);

--- a/public/modules/packing/config/packing.client.routes.js
+++ b/public/modules/packing/config/packing.client.routes.js
@@ -1,8 +1,8 @@
 'use strict';
 
 // Setting up routes
-angular.module('packing').config(['$stateProvider',
-	function($stateProvider) {
+angular.module('packing').config(['$stateProvider', 'AuthenticationProvider',
+	function($stateProvider, AuthenticationProvider) {
 		// Packing state routing
 		$stateProvider.
 		state('root.packing', {
@@ -12,6 +12,9 @@ angular.module('packing').config(['$stateProvider',
 					templateUrl: 'modules/packing/views/packing.client.view.html',
 					controller: 'PackingController as packingCtrl'
 				}
+			},
+			resolve: {
+				CurrentUser: AuthenticationProvider.requireAdminUser
 			}
 		});
 	}

--- a/public/modules/packing/packing.client.module.js
+++ b/public/modules/packing/packing.client.module.js
@@ -1,4 +1,4 @@
 'use strict';
 
 // Use application configuration module to register a new module
-ApplicationConfiguration.registerModule('packing');
+ApplicationConfiguration.registerModule('packing', ['users']);

--- a/public/modules/questionnaire/config/questionnaire.client.routes.js
+++ b/public/modules/questionnaire/config/questionnaire.client.routes.js
@@ -1,8 +1,8 @@
 'use strict';
 
 // Setting up routes
-angular.module('questionnaire').config(['$stateProvider',
-	function($stateProvider) {
+angular.module('questionnaire').config(['$stateProvider', 'AuthenticationProvider',
+	function($stateProvider, AuthenticationProvider) {
 		// Questionnaire state routing
 		$stateProvider.
 		state('root.questionnaires', {
@@ -12,6 +12,9 @@ angular.module('questionnaire').config(['$stateProvider',
 					templateUrl: 'modules/questionnaire/views/questionnaires.client.view.html',
 					controller: 'QuestionnaireController as questionnaireCtrl'
 				}
+			},
+			resolve: {
+				CurrentUser: AuthenticationProvider.requireAdminUser
 			}
 		}).
 		state('root.qtest', {
@@ -21,6 +24,9 @@ angular.module('questionnaire').config(['$stateProvider',
 					templateUrl: 'modules/questionnaire/views/qtest.client.view.html',
 					controller: 'qTestController as qtCtrl'
 				}
+			},
+			resolve: {
+				CurrentUser: AuthenticationProvider.requireAdminUser
 			}
 		});
 	}

--- a/public/modules/questionnaire/questionnaire.client.module.js
+++ b/public/modules/questionnaire/questionnaire.client.module.js
@@ -1,4 +1,4 @@
 'use strict';
 
 // Use application configuration module to register a new module
-ApplicationConfiguration.registerModule('questionnaire');
+ApplicationConfiguration.registerModule('questionnaire', ['users']);

--- a/public/modules/schedule/config/schedule.client.routes.js
+++ b/public/modules/schedule/config/schedule.client.routes.js
@@ -1,8 +1,8 @@
 'use strict';
 
 // Setting up routes
-angular.module('schedule').config(['$stateProvider',
-	function($stateProvider) {
+angular.module('schedule').config(['$stateProvider', 'AuthenticationProvider',
+	function($stateProvider, AuthenticationProvider) {
 		// Schedule state routing
 		$stateProvider.
 		state('root.schedules', {
@@ -12,6 +12,9 @@ angular.module('schedule').config(['$stateProvider',
 					templateUrl: 'modules/schedule/views/schedules.client.view.html',
 					controller: 'ScheduleController as scheduleCtrl'
 				}
+			},
+			resolve: {
+				CurrentUser: AuthenticationProvider.requireAdminUser
 			}
 		});
 	}

--- a/public/modules/schedule/schedule.client.module.js
+++ b/public/modules/schedule/schedule.client.module.js
@@ -1,4 +1,4 @@
 'use strict';
 
 // Use application configuration module to register a new module
-ApplicationConfiguration.registerModule('schedule');
+ApplicationConfiguration.registerModule('schedule', ['users']);

--- a/public/modules/settings/config/settings.client.routes.js
+++ b/public/modules/settings/config/settings.client.routes.js
@@ -1,8 +1,8 @@
 'use strict';
 
 // Setting up routes
-angular.module('settings').config(['$stateProvider', '$urlRouterProvider',
-	function($stateProvider, $urlRouterProvider) {
+angular.module('settings').config(['$stateProvider', '$urlRouterProvider', 'AuthenticationProvider',
+	function($stateProvider, $urlRouterProvider, AuthenticationProvider) {
 		// Routing for general settings page
 		$stateProvider.
 		state('root.changeSettings', {
@@ -15,6 +15,9 @@ angular.module('settings').config(['$stateProvider', '$urlRouterProvider',
 				'basic-settings@root.changeSettings': {
 					templateUrl: 'modules/settings/views/partials/basic-settings.partial.html'
 				}
+			},
+			resolve: {
+				CurrentUser: AuthenticationProvider.requireAdminUser
 			}
 		});
 	}

--- a/public/modules/settings/controllers/settings.client.controller.js
+++ b/public/modules/settings/controllers/settings.client.controller.js
@@ -11,9 +11,6 @@
 		// This provides Authentication context
 		self.authentication = Authentication;
 
-		// If user is not signed in redirect to signin
-		if(!user) $state.go('root.signin');
-
 		SettingsObject.readSettings().
 			then(function successCallback(response){
 				$rootScope.tconfig = response.data;

--- a/public/modules/settings/settings.client.module.js
+++ b/public/modules/settings/settings.client.module.js
@@ -1,4 +1,4 @@
 'use strict';
 
 // Use application configuration module to register a new module
-ApplicationConfiguration.registerModule('settings');
+ApplicationConfiguration.registerModule('settings', ['users']);

--- a/public/modules/users/services/authentication.client.service.js
+++ b/public/modules/users/services/authentication.client.service.js
@@ -1,14 +1,38 @@
 'use strict';
 
 // Authentication service for user variables
-angular.module('users').factory('Authentication', [
-	function() {
-		var _this = this;
+angular.module('users').provider('Authentication', ['$windowProvider', function($windowProvider) {
+	var _this = this;
+	var $window = $windowProvider.$get();
 
-		_this._data = {
-			user: window.user
-		};
-
+	// If a user is logged on, the server inserts a script tag in the html that sets window.user
+	_this._data = {user: $window.user};
+	
+	// When used as a factory, Authentication will provide the return value from $get
+	this.$get = function () {
 		return _this._data;
-	}
-]);
+	};
+
+	// This is used in ui-router resolve to ensure an admin role is logged in
+	this.requireAdminUser = ['$q', '$state', '$timeout', function ($q, $state, $timeout) {
+		var deferred = $q.defer();
+		if (!_this._data.user) {
+			// Not signed in
+			$timeout(function() {
+				deferred.reject();
+				$state.go('root.signin');
+			}, 100);
+		} else if (_this._data.user.roles.indexOf('admin') < 0) {
+			// Not an admin user
+ 			$timeout(function() {
+				deferred.reject();
+				$state.go('root');
+			}, 100);
+		} else {
+			// admin user logged in. Set the promise value to the user data
+			deferred.resolve(_this._data.user);
+		}
+		return deferred.promise;		
+	}];
+}]);
+

--- a/public/modules/volunteer/config/volunteer.client.routes.js
+++ b/public/modules/volunteer/config/volunteer.client.routes.js
@@ -1,8 +1,8 @@
 'use strict';
 
 // Setting up route
-angular.module('volunteer').config(['$stateProvider',
-	function($stateProvider) {
+angular.module('volunteer').config(['$stateProvider', 'AuthenticationProvider',
+	function($stateProvider, AuthenticationProvider) {
 		// Volunteer state routing for user
 		$stateProvider.
 		state('root.createVolunteerUser', {
@@ -56,6 +56,9 @@ angular.module('volunteer').config(['$stateProvider',
 					templateUrl: 'modules/volunteer/views/admin/list-volunteers.client.view.html',
 					controller: 'VolunteerAdminController as volunteerCtrl'
 				}
+			},
+			resolve: {
+				CurrentUser: AuthenticationProvider.requireAdminUser
 			}
 		}).
 		state('root.viewVolunteerAdmin', {
@@ -65,6 +68,9 @@ angular.module('volunteer').config(['$stateProvider',
 					templateUrl: 'modules/volunteer/views/view-volunteer.client.view.html',
 					controller: 'VolunteerAdminController as volunteerCtrl'
 				}
+			},
+			resolve: {
+				CurrentUser: AuthenticationProvider.requireAdminUser
 			}
 		}).
 		state('root.editVolunteerAdmin', {
@@ -77,6 +83,9 @@ angular.module('volunteer').config(['$stateProvider',
 				'general-info@root.editVolunteerAdmin': {
 					templateUrl: 'modules/volunteer/views/partials/general-info.partial.html'
 				}
+			},
+			resolve: {
+				CurrentUser: AuthenticationProvider.requireAdminUser
 			}
 		});
 	}

--- a/public/modules/volunteer/controllers/admin-volunteer.client.controller.js
+++ b/public/modules/volunteer/controllers/admin-volunteer.client.controller.js
@@ -10,9 +10,6 @@
 		// This provides Authentication context
 		self.authentication = Authentication;
 
-		// Verify if user has admin role, redirect to home otherwise
-		if (self.authentication.user.roles.indexOf('admin') < 0) $state.go('root');
-
 		// Add plugins into datatable
 		self.dtOptions = {
 			dom: 'Tlfrtip',

--- a/public/modules/volunteer/volunteer.client.module.js
+++ b/public/modules/volunteer/volunteer.client.module.js
@@ -1,4 +1,4 @@
 'use strict';
 
 // Use application configuration module to register a new module
-ApplicationConfiguration.registerModule('volunteer');
+ApplicationConfiguration.registerModule('volunteer', ['users']);


### PR DESCRIPTION
Move code that checks for an admin user on the client out of the controllers.  Accomplished by

- Changing the Authorization factory to a provider so it can be used in the route config areas.
- Adding a method to Authorization to check for an admin user
- Adding the resolve property to the ui-router routes that require admin access
- Setting the resolve property to the Authorization method to check for administrator

closes #34