### PR TITLE
User ui-router resolve to check for logged in user

### DIFF
--- a/public/modules/customer/config/user-customer.client.routes.js
+++ b/public/modules/customer/config/user-customer.client.routes.js
@@ -1,8 +1,8 @@
 'use strict';
 
 // Setting up route
-angular.module('customer').config(['$stateProvider',
-	function($stateProvider){
+angular.module('customer').config(['$stateProvider', 'AuthenticationProvider',
+	function($stateProvider, AuthenticationProvider){
 		// Customer state routing for user
 		$stateProvider.
 		state('root.createCustomerUser', {
@@ -21,6 +21,9 @@ angular.module('customer').config(['$stateProvider',
 				'waiver@root.createCustomerUser': {
 					templateUrl: 'modules/customer/views/partials/waiver.partial.html'
 				}
+			},
+			resolve: {
+				CurrentUser: AuthenticationProvider.requireLoggedIn
 			}
 		}).
 		state('root.createCustomerUser-success', {
@@ -29,6 +32,9 @@ angular.module('customer').config(['$stateProvider',
 				'content@': {
 					templateUrl: 'modules/customer/views/user/create-customer-success.client.view.html'
 				}
+			},
+			resolve: {
+				CurrentUser: AuthenticationProvider.requireLoggedIn
 			}
 		}).
 		state('root.viewCustomerUser', {
@@ -41,6 +47,9 @@ angular.module('customer').config(['$stateProvider',
 				'dynamic-view@root.viewCustomerUser': {
 					templateUrl: 'modules/core/views/partials/dynamic-view.partial.html'
 				}
+			},
+			resolve: {
+				CurrentUser: AuthenticationProvider.requireLoggedIn
 			}
 		}).
 		state('root.editCustomerUser', {
@@ -56,6 +65,9 @@ angular.module('customer').config(['$stateProvider',
 				'household@root.editCustomerUser': {
 					templateUrl: 'modules/customer/views/partials/household.partial.html'
 				}
+			},
+			resolve: {
+				CurrentUser: AuthenticationProvider.requireLoggedIn
 			}
 		});
 	}

--- a/public/modules/customer/controllers/user-customer.client.controller.js
+++ b/public/modules/customer/controllers/user-customer.client.controller.js
@@ -11,9 +11,6 @@
 		// This provides Authentication context
 		self.authentication = Authentication;
 
-		// If user is not signed in redirect to signin
-		if (!user) $state.go('root.signin');
-
 		// Redirect to edit if user has already applied
 		if (user && user.hasApplied && $state.is('root.createCustomerUser')) $state.go('root.editCustomerUser', { customerId: user._id });
 

--- a/public/modules/donor/config/donor.client.routes.js
+++ b/public/modules/donor/config/donor.client.routes.js
@@ -15,6 +15,9 @@ angular.module('donor').config(['$stateProvider', 'AuthenticationProvider',
 				'dynamic-form@root.createDonorUser': {
 					templateUrl: 'modules/core/views/partials/dynamic-form.partial.html'
 				}
+			},
+			resolve: {
+				CurrentUser: AuthenticationProvider.requireLoggedIn
 			}
 		}).
 		state('root.createDonorUser-success', {
@@ -23,6 +26,9 @@ angular.module('donor').config(['$stateProvider', 'AuthenticationProvider',
 				'content@': {
 					templateUrl: 'modules/donor/views/user/create-donor-success.client.view.html'
 				}
+			},
+			resolve: {
+				CurrentUser: AuthenticationProvider.requireLoggedIn
 			}
 		}).
 		state('root.viewDonorUser', {
@@ -32,6 +38,9 @@ angular.module('donor').config(['$stateProvider', 'AuthenticationProvider',
 					templateUrl: 'modules/donor/views/view-donor.client.view.html',
 					controller: 'DonorUserController as dynCtrl'
 				}
+			},
+			resolve: {
+				CurrentUser: AuthenticationProvider.requireLoggedIn
 			}
 		}).
 		state('root.editDonorUser', {
@@ -44,6 +53,9 @@ angular.module('donor').config(['$stateProvider', 'AuthenticationProvider',
 				'dynamic-form@root.editDonorUser': {
 					templateUrl: 'modules/core/views/partials/dynamic-form.partial.html'
 				}
+			},
+			resolve: {
+				CurrentUser: AuthenticationProvider.requireLoggedIn
 			}
 		});
 

--- a/public/modules/donor/controllers/user-donor.client.controller.js
+++ b/public/modules/donor/controllers/user-donor.client.controller.js
@@ -11,9 +11,6 @@
 		// This provides Authentication context
 		self.authentication = Authentication;
 
-		// If user is not signed in redirect to signin
-		if(!user) $state.go('root.signin');
-
 		self.dynMethods = Form.methods;
 		formInit.get().then(function(res) {
 			var init = self.dynMethods.generate(self.dynType, res, 'qDonors');

--- a/public/modules/driver/config/driver.client.routes.js
+++ b/public/modules/driver/config/driver.client.routes.js
@@ -15,6 +15,9 @@ angular.module('driver').config(['$stateProvider', 'AuthenticationProvider',
 					templateUrl: 'modules/driver/views/user-driver.client.view.html',
 					controller: 'DriverUserController as driverCtrl'
 				}
+			},
+			resolve: {
+				CurrentUser: AuthenticationProvider.requireLoggedIn
 			}
 		}).
 		// Driver state routing for admin

--- a/public/modules/users/config/users.client.routes.js
+++ b/public/modules/users/config/users.client.routes.js
@@ -1,8 +1,8 @@
 'use strict';
 
 // Setting up route
-angular.module('users').config(['$stateProvider',
-	function($stateProvider) {
+angular.module('users').config(['$stateProvider', 'AuthenticationProvider',
+	function($stateProvider, AuthenticationProvider) {
 		// Users state routing
 		$stateProvider.
 		state('root.profile', {
@@ -12,6 +12,9 @@ angular.module('users').config(['$stateProvider',
 					templateUrl: 'modules/users/views/settings/edit-profile.client.view.html',
 					controller: 'SettingsController as settingsCtrl'
 				}
+			},
+			resolve: {
+				CurrentUser: AuthenticationProvider.requireLoggedIn
 			}
 		}).
 		state('root.password', {
@@ -21,6 +24,9 @@ angular.module('users').config(['$stateProvider',
 					templateUrl: 'modules/users/views/settings/change-password.client.view.html',
 					controller: 'SettingsController as settingsCtrl'
 				}
+			},
+			resolve: {
+				CurrentUser: AuthenticationProvider.requireLoggedIn
 			}
 		}).
 		state('root.accounts', {
@@ -29,6 +35,9 @@ angular.module('users').config(['$stateProvider',
 				'content@': {
 					templateUrl: 'modules/users/views/settings/social-accounts.client.view.html'
 				}
+			},
+			resolve: {
+				CurrentUser: AuthenticationProvider.requireLoggedIn
 			}
 		}).
 		state('root.signup', {

--- a/public/modules/users/services/authentication.client.service.js
+++ b/public/modules/users/services/authentication.client.service.js
@@ -34,5 +34,20 @@ angular.module('users').provider('Authentication', ['$windowProvider', function(
 		}
 		return deferred.promise;		
 	}];
+
+	// This is used in ui-router resolve to ensure a user is logged in
+	this.requireLoggedIn = ['$q', '$state', '$timeout', function ($q, $state, $timeout) {
+		var deferred = $q.defer();
+		if (!_this._data.user) {
+			// Not signed in
+			$timeout(function() {
+				deferred.reject();
+				$state.go('root.signin');
+			}, 100);
+		} else {
+			deferred.resolve(_this._data.user);
+		}
+		return deferred.promise;		
+	}];
 }]);
 

--- a/public/modules/volunteer/config/volunteer.client.routes.js
+++ b/public/modules/volunteer/config/volunteer.client.routes.js
@@ -15,6 +15,9 @@ angular.module('volunteer').config(['$stateProvider', 'AuthenticationProvider',
 				'dynamic-form@root.createVolunteerUser': {
 					templateUrl: 'modules/core/views/partials/dynamic-form.partial.html'
 				}
+			},
+			resolve: {
+				CurrentUser: AuthenticationProvider.requireLoggedIn
 			}
 		}).
 		state('root.createVolunteerUser-success', {
@@ -23,6 +26,9 @@ angular.module('volunteer').config(['$stateProvider', 'AuthenticationProvider',
 				'content@': {
 					templateUrl: 'modules/volunteer/views/user/create-volunteer-success.client.view.html'
 				}
+			},
+			resolve: {
+				CurrentUser: AuthenticationProvider.requireLoggedIn
 			}
 		}).
 		state('root.viewVolunteerUser', {
@@ -35,6 +41,9 @@ angular.module('volunteer').config(['$stateProvider', 'AuthenticationProvider',
 				'dynamic-view@root.viewVolunteerUser': {
 					templateUrl: 'modules/core/views/partials/dynamic-view.partial.html'
 				}
+			},
+			resolve: {
+				CurrentUser: AuthenticationProvider.requireLoggedIn
 			}
 		}).
 		state('root.editVolunteerUser', {
@@ -47,6 +56,9 @@ angular.module('volunteer').config(['$stateProvider', 'AuthenticationProvider',
 				'dynamic-form@root.editVolunteerUser': {
 					templateUrl: 'modules/core/views/partials/dynamic-form.partial.html'
 				}
+			},
+			resolve: {
+				CurrentUser: AuthenticationProvider.requireLoggedIn
 			}
 		});
 

--- a/public/modules/volunteer/controllers/user-volunteer.client.controller.js
+++ b/public/modules/volunteer/controllers/user-volunteer.client.controller.js
@@ -10,9 +10,6 @@
 		// This provides Authentication context
 		self.authentication = Authentication;
 
-		// If user is not signed in redirect to signin
-		if(!user) $state.go('root.signin');
-
 		// Redirect to edit if user has already applied
 		if (user && user.hasApplied && $state.is('root.createVolunteerUser')) $state.go('root.editVolunteerUser', { volunteerId: user._id });
 


### PR DESCRIPTION
This is applying the same logic from what I did in  [0a3832e](https://github.com/freeCodeCamp/food-bank-app/commit/0a3832e020f277336a7c5c85481c528c126a2df9) to the user routes.  

I created a `requireLoggedIn` method in the `AuthenticationProvider` that will redirect to the login page if there is not a logged in user.  Then I added this method to the ui-router resolve property of every route that requires a non-admin to be logged in. 

I think that this could be further improved to check for a role rather than simply if someone was just logged on.  This could be done by making a similar method to `AuthenticationProvider.requireAdminUser` for each type of role(i.e. requireCustomerUser, requireDonorUser).  I wanted to figure out how to just have one method requireRole(role) that you can use for any given role but I couldn't find a way to do that.