### PR TITLE
reinstated food service

### DIFF
--- a/public/modules/food/services/food.client.service.js
+++ b/public/modules/food/services/food.client.service.js
@@ -26,4 +26,14 @@ angular.module('food').factory('FoodAdmin', ['$resource',
 	function($resource) {
 		return $resource('foods/', {});
 	}
+]).factory('Food', ['$resource',
+	function($resource) {
+		return $resource('admin/foods/:foodId', {
+			foodId: '@_id'
+		}, {
+			update: {
+				method: 'PUT'
+			}
+		});
+	}
 ]);


### PR DESCRIPTION
The food service had been accidentally removed in this commit:

https://github.com/freeCodeCamp/food-bank-app/commit/cfbda6be313f15a0b8160569742e40187eb6a783

I should have the driver route directions ready for a new commit & approval at some point today hopefully. 

Also - After updating the staging branch with a pull request, there are 6 linting errors on the CLI, and in the browser console there's a warning not to use XMLHttpRequest because it is synchronous. I'll include a factory function in my next commit which will make the request async and also remove the linting errors.